### PR TITLE
외출/외박 신청 시 도담도담이 종료되는 버그 수정

### DIFF
--- a/buildSrc/src/main/java/ProjectProperties.kt
+++ b/buildSrc/src/main/java/ProjectProperties.kt
@@ -5,8 +5,8 @@ object ProjectProperties {
     const val COMPILE_SDK_VERSION = 32
     const val MIN_SDK_VERSION = 26
     const val TARGET_SDK_VERSION = 32
-    const val VERSION_CODE = 55
-    const val VERSION_NAME = "2.1.0"
+    const val VERSION_CODE = 60
+    const val VERSION_NAME = "2.1.1"
     const val JVM_TARGET = "11"
     val JAVA_VERSION = JavaVersion.VERSION_11
 

--- a/data/src/main/java/kr/hs/dgsw/smartschool/data/mapper/OutItemMapper.kt
+++ b/data/src/main/java/kr/hs/dgsw/smartschool/data/mapper/OutItemMapper.kt
@@ -8,17 +8,18 @@ import kr.hs.dgsw.smartschool.domain.model.member.StudentId
 import kr.hs.dgsw.smartschool.domain.model.member.TeacherId
 import kr.hs.dgsw.smartschool.domain.model.out.OutItem
 import kr.hs.dgsw.smartschool.domain.model.out.OutStatus
+import java.util.Date
 
 fun OutItemResponse.toModel(): OutItem = OutItem(
-    arrivedDate = this.arrivedDate,
-    checkedDate = this.checkedDate,
+    arrivedDate = this.arrivedDate ?: Date(),
+    checkedDate = this.checkedDate ?: Date(),
     endOutDate = this.endOutDate,
     id = this.id,
     reason = this.reason,
     startOutDate = this.startOutDate,
     status = this.status.toModel(),
     student = this.student.toModel(),
-    teacher = this.teacher.toModel()
+    teacher = this.teacher?.toModel() ?: TeacherId("")
 )
 
 fun OutStatusResponse.toModel(): OutStatus = when (this.name) {

--- a/data/src/main/java/kr/hs/dgsw/smartschool/data/network/interceptor/TokenInterceptor.kt
+++ b/data/src/main/java/kr/hs/dgsw/smartschool/data/network/interceptor/TokenInterceptor.kt
@@ -3,18 +3,12 @@ package kr.hs.dgsw.smartschool.data.network.interceptor
 import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
-import kr.hs.dgsw.smartschool.data.database.entity.AccountEntity
 import kr.hs.dgsw.smartschool.data.datasource.AccountDataSource
 import kr.hs.dgsw.smartschool.data.util.AppDispatchers
-import kr.hs.dgsw.smartschool.domain.exception.TokenException
 import kr.hs.dgsw.smartschool.domain.model.token.Token
-import kr.hs.dgsw.smartschool.domain.usecase.auth.LoginUseCase
 import kr.hs.dgsw.smartschool.domain.usecase.token.TokenUseCases
-import kr.hs.dgsw.smartschool.domain.util.Resource
 import okhttp3.Interceptor
 import okhttp3.Protocol
 import okhttp3.Request
@@ -23,7 +17,6 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import org.json.JSONException
 import retrofit2.HttpException
 import javax.inject.Inject
-import kotlin.math.acos
 
 class TokenInterceptor @Inject constructor(
 //    private val loginUseCase: LoginUseCase,

--- a/data/src/main/java/kr/hs/dgsw/smartschool/data/network/interceptor/TokenInterceptor.kt
+++ b/data/src/main/java/kr/hs/dgsw/smartschool/data/network/interceptor/TokenInterceptor.kt
@@ -23,9 +23,10 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import org.json.JSONException
 import retrofit2.HttpException
 import javax.inject.Inject
+import kotlin.math.acos
 
 class TokenInterceptor @Inject constructor(
-    private val loginUseCase: LoginUseCase,
+//    private val loginUseCase: LoginUseCase,
     private val tokenUseCases: TokenUseCases,
     private val accountDataSource: AccountDataSource,
     private val appDispatcher: AppDispatchers
@@ -36,12 +37,11 @@ class TokenInterceptor @Inject constructor(
 
     private lateinit var token: Token
     private lateinit var response: Response
-    private lateinit var account: AccountEntity
 
     private val mutex = Mutex()
 
     private val getAccountJob = CoroutineScope(appDispatcher.io).async {
-        account = accountDataSource.getAccount()
+        accountDataSource.getAccount()
     }
 
     @Synchronized
@@ -73,7 +73,7 @@ class TokenInterceptor @Inject constructor(
             fetchToken()
         } catch (e: HttpException) {
             // 어떤 이유로 오류 발생 시
-            getTokenToLogin()
+//            getTokenToLogin()
         }
         response = this.proceedWithToken(this.request())
 
@@ -90,7 +90,7 @@ class TokenInterceptor @Inject constructor(
 
     private fun Interceptor.Chain.login(): Response {
         // 로그인으로 토큰 교체
-        getTokenToLogin()
+//        getTokenToLogin()
 
         // request에 토큰을 붙여서 새로운 request 생성 -> 진행
         response = this.proceedWithToken(this.request())
@@ -117,22 +117,21 @@ class TokenInterceptor @Inject constructor(
         tokenUseCases.updateNewToken().let { token = it }
     }
 
-    private fun getTokenToLogin() {
-        runBlocking(appDispatcher.io) {
-            // 계정을 DB에서 받아옴
-            getAccountJob.join()
-
-            loginUseCase(LoginUseCase.Params(account.id, account.pw, false)).onEach {
-                if (it is Resource.Success) {
-                    // 성공 시 로그인 딴에서 DB에 token 값을 저장하므로 DB에서 token을 가져오는 작업 수행
-                    setToken()
-                } else if (it is Resource.Error) {
-                    Log.d("TokenTest", "Here is Get token to login")
-                    throw TokenException("세션이 만료되었습니다.")
-                }
-            }.launchIn(CoroutineScope(appDispatcher.io))
-        }
-    }
+//    private fun getTokenToLogin() {
+//        runBlocking(appDispatcher.io) {
+//            // 계정을 DB에서 받아옴
+//            val account = getAccountJob.await()
+//            loginUseCase(LoginUseCase.Params(account.id, account.pw, false)).onEach {
+//                if (it is Resource.Success) {
+//                    // 성공 시 로그인 딴에서 DB에 token 값을 저장하므로 DB에서 token을 가져오는 작업 수행
+//                    setToken()
+//                } else if (it is Resource.Error) {
+//                    Log.d("TokenTest", "Here is Get token to login")
+//                    throw TokenException("세션이 만료되었습니다.")
+//                }
+//            }.launchIn(CoroutineScope(appDispatcher.io))
+//        }
+//    }
 
     // ---------------------------------------------------------------------------------
     private fun Interceptor.Chain.proceedWithToken(req: Request): Response =

--- a/data/src/main/java/kr/hs/dgsw/smartschool/data/network/response/out/OutItemResponse.kt
+++ b/data/src/main/java/kr/hs/dgsw/smartschool/data/network/response/out/OutItemResponse.kt
@@ -14,15 +14,15 @@ import java.util.Locale
 
 @Parcelize
 open class OutItemResponse(
-    val arrivedDate: Date,
-    val checkedDate: Date,
+    val arrivedDate: Date?,
+    val checkedDate: Date?,
     val endOutDate: Date,
     val id: Int,
     val reason: String,
     val startOutDate: Date,
     val status: OutStatusResponse,
     @TypeParceler<StudentIdResponse, StudentIdParceler> val student: StudentIdResponse,
-    @TypeParceler<TeacherIdResponse, TeacherIdParceler> val teacher: TeacherIdResponse
+    @TypeParceler<TeacherIdResponse?, TeacherIdParceler> val teacher: TeacherIdResponse?
 ) : Serializable, Parcelable {
 
     val startDate: String

--- a/data/src/main/java/kr/hs/dgsw/smartschool/data/util/parceler/TeacherIdParceler.kt
+++ b/data/src/main/java/kr/hs/dgsw/smartschool/data/util/parceler/TeacherIdParceler.kt
@@ -4,10 +4,10 @@ import android.os.Parcel
 import kotlinx.parcelize.Parceler
 import kr.hs.dgsw.smartschool.data.network.response.member.TeacherIdResponse
 
-object TeacherIdParceler : Parceler<TeacherIdResponse> {
+object TeacherIdParceler : Parceler<TeacherIdResponse?> {
 
     override fun create(parcel: Parcel) = TeacherIdResponse(parcel.readString() ?: "")
 
-    override fun TeacherIdResponse.write(parcel: Parcel, flags: Int) =
-        parcel.writeString(id)
+    override fun TeacherIdResponse?.write(parcel: Parcel, flags: Int) =
+        parcel.writeString(this?.id)
 }


### PR DESCRIPTION
## 문제 상황
외출/외박을 신청시 도담도담이 강제종료가 된다.
## 문제 원인
Domain과 Data 레이어의 모델을 분리하면서 만든 Mapper에서 NPE가 발생했습니다.
## 작업 사항
* 버전 2.1.0 -> 2.1.1
* 버전 코드 55 -> 60
* OutItemResponse의 프로퍼티를 nullable하게 변경, OutItemMapper에서 null 값 처리
* TokenIntercepter에 있는 room에 저장되어있는 id, pw로 token을 발급받는 로직 삭제 ( 업데이트시 도담도담이 실행되지 않는 문제의 원인 )
## 기타
* 도담도담을 업데이트 하면 앱이 실행되지 않는 오류 해결했습니다.
* 위 오류를 해결하기 위해 구글 내부테스트를 하면서 버전코드를 60까지 올렸습니다. 
