### PR TITLE
심자 신청 가능 시간 제한, 급식 오류 수정

### DIFF
--- a/buildSrc/src/main/java/ProjectProperties.kt
+++ b/buildSrc/src/main/java/ProjectProperties.kt
@@ -5,8 +5,8 @@ object ProjectProperties {
     const val COMPILE_SDK_VERSION = 32
     const val MIN_SDK_VERSION = 26
     const val TARGET_SDK_VERSION = 32
-    const val VERSION_CODE = 62
-    const val VERSION_NAME = "2.2.1"
+    const val VERSION_CODE = 63
+    const val VERSION_NAME = "2.2.2"
     const val JVM_TARGET = "11"
     val JAVA_VERSION = JavaVersion.VERSION_11
 

--- a/data/src/main/java/kr/hs/dgsw/smartschool/data/datasource/MealDataSource.kt
+++ b/data/src/main/java/kr/hs/dgsw/smartschool/data/datasource/MealDataSource.kt
@@ -41,11 +41,13 @@ class MealDataSource @Inject constructor(
                 mealList.add(map.value)
             }
 
-            cache.insertMealList(
-                mealList.toList().map { meal ->
-                    meal.toEntity()
-                }
-            )
+            if (!mealList.all { it.breakfast == null && it.lunch == null && it.dinner == null }) {
+                cache.insertMealList(
+                    mealList.toList().map { meal ->
+                        meal.toEntity()
+                    }
+                )
+            }
         }
 
     suspend fun getCalorieOfMeal(year: Int, month: Int, day: Int): Calorie {
@@ -80,10 +82,12 @@ class MealDataSource @Inject constructor(
                 calorieList.add(map.value)
             }
 
-            cache.insertCalorieList(
-                calorieList.toList().map { calorie ->
-                    calorie.toEntity()
-                }
-            )
+            if (!calorieList.all { it.breakfast == null && it.lunch == null && it.dinner == null }) {
+                cache.insertCalorieList(
+                    calorieList.toList().map { calorie ->
+                        calorie.toEntity()
+                    }
+                )
+            }
         }
 }

--- a/presentation/src/main/java/kr/hs/dgsw/smartschool/dodamdodam/features/nightstudy/write/NightStudyWriteViewModel.kt
+++ b/presentation/src/main/java/kr/hs/dgsw/smartschool/dodamdodam/features/nightstudy/write/NightStudyWriteViewModel.kt
@@ -138,7 +138,7 @@ class NightStudyWriteViewModel @Inject constructor(
                 return
             }
             LocalTime.now() > LocalTime.of(16, 30) -> {
-                applyError("4시 30분 이후로는 심지 신청이 불가능 합니다")
+                applyError("4시 30분 이후로는 심자 신청이 불가능 합니다")
             }
             else -> applyNightStudy(id)
         }

--- a/presentation/src/main/java/kr/hs/dgsw/smartschool/dodamdodam/features/nightstudy/write/NightStudyWriteViewModel.kt
+++ b/presentation/src/main/java/kr/hs/dgsw/smartschool/dodamdodam/features/nightstudy/write/NightStudyWriteViewModel.kt
@@ -18,9 +18,7 @@ import kr.hs.dgsw.smartschool.domain.usecase.nightstudy.NightStudyUseCases
 import kr.hs.dgsw.smartschool.domain.usecase.place.GetDormitoryPlaceUseCase
 import java.time.LocalDateTime
 import java.time.LocalTime
-import java.time.ZoneId
 import java.time.ZoneOffset
-import java.util.Calendar
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -139,7 +137,7 @@ class NightStudyWriteViewModel @Inject constructor(
                 applyError("심자 장소를 선택해주세요")
                 return
             }
-            LocalTime.now() > LocalTime.of(16,30) -> {
+            LocalTime.now() > LocalTime.of(16, 30) -> {
                 applyError("4시 30분 이후로는 심지 신청이 불가능 합니다")
             }
             else -> applyNightStudy(id)

--- a/presentation/src/main/java/kr/hs/dgsw/smartschool/dodamdodam/features/nightstudy/write/NightStudyWriteViewModel.kt
+++ b/presentation/src/main/java/kr/hs/dgsw/smartschool/dodamdodam/features/nightstudy/write/NightStudyWriteViewModel.kt
@@ -16,6 +16,11 @@ import kr.hs.dgsw.smartschool.domain.model.nightstudy.NightStudyItem
 import kr.hs.dgsw.smartschool.domain.usecase.nightstudy.ApplyNightStudy
 import kr.hs.dgsw.smartschool.domain.usecase.nightstudy.NightStudyUseCases
 import kr.hs.dgsw.smartschool.domain.usecase.place.GetDormitoryPlaceUseCase
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.Calendar
 import java.util.Date
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -44,6 +49,8 @@ class NightStudyWriteViewModel @Inject constructor(
     val nightStudyWriteState: SharedFlow<NightStudyWriteState> = _nightStudyWriteState
 
     init {
+        val targetDate = LocalDateTime.now().plusDays(12)
+        endNightStudyDate.value = Date.from(targetDate.toInstant(ZoneOffset.MIN))
         getDormitoryPlace()
     }
 
@@ -116,7 +123,6 @@ class NightStudyWriteViewModel @Inject constructor(
                 applyError("휴대폰 사용 사유는 250자 이하로 입력해주세요")
                 return
             }
-
             TimeUnit.DAYS.convert(endDate!!.time - startDate!!.time, TimeUnit.MILLISECONDS) > 13 -> {
                 applyError("최대 2주까지만 선택 가능합니다")
                 return
@@ -132,6 +138,9 @@ class NightStudyWriteViewModel @Inject constructor(
             id == null -> {
                 applyError("심자 장소를 선택해주세요")
                 return
+            }
+            LocalTime.now() > LocalTime.of(16,30) -> {
+                applyError("4시 30분 이후로는 심지 신청이 불가능 합니다")
             }
             else -> applyNightStudy(id)
         }


### PR DESCRIPTION
## 개요
학교 규정이 변경되어 4시 30분 이후부터는 심자 신청이 불가능 하게 되었습니다.
또한 현재 급식이 존재하지 않는 미래의 달의 급식을 불러올 경우 전부 빈 값이 들어와 DB에 저장되어 나중에 급식이 추가 되더라도 이미 DB에 빈 값이 저장되버려 새로 급식을 호출하지 않아 급식이 보이지 않는 버그가 발생했습니다.

## 문제상황
심자신청이 4시30분 이후로는 불가능 하도록 변경되어야 합니다.
급식이 불러와지지 않는 오류를 수정하여야 합니다.

## 작업상황
- [x] 심자신청이 4시30분 이후로는 불가능 하게 변경
- [x] 급식을 불러왔을 떄 전부 빈 값이라면 DB에 저장 하지 않도록 변경